### PR TITLE
Update artifactId for Bukkit in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
         <dependency>
             <groupId>org.bukkit</groupId>
-            <artifactId>craftbukkit</artifactId>
+            <artifactId>bukkit</artifactId>
             <version>1.14-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
Based on the file structure on [Spigot's Repo](https://hub.spigotmc.org/nexus/content/repositories/snapshots/), the artifactId for Bukkit (in `pom.xml`) should be `bukkit`, not `craftbukkit`. I don't know if Spigot changed something, but it fixed an error I was getting when trying to build the plugin.