### PR TITLE
Remove unused craftbukkit dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,13 +24,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>craftbukkit</artifactId>
-            <version>1.14-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.6</version>


### PR DESCRIPTION
Build wasn't portable because it previously depended on craftbukkit (and didn't even use it...)